### PR TITLE
Allow GraphiQL to be enabled/disabled

### DIFF
--- a/src/classes/RequestHandler.ts
+++ b/src/classes/RequestHandler.ts
@@ -38,8 +38,9 @@ class RequestHandler {
 	public constructor(schema: GraphQLSchema, opts: RequestHandlerOptions = {}) {
 		this.graphQLExecutor = new GraphQLExecutor(schema);
 
-		const { showGraphiQL = false, validationRules } = opts;
-		this.showGraphiQL = showGraphiQL;
+		const { showGraphiQL, validationRules } = opts;
+
+		this.showGraphiQL = showGraphiQL ?? process.env.NODE_ENV !== 'production';
 		this.validationRules = validationRules;
 	}
 

--- a/src/mixins/gatewayMixin.ts
+++ b/src/mixins/gatewayMixin.ts
@@ -15,13 +15,14 @@ interface GatewayService extends Service {
 
 export interface GatewayMixinOptions {
 	routeOptions?: Route;
+	showGraphiQL?: boolean;
 	validationRules?: readonly ValidationRule[];
 }
 
 export default function gatewayMixin(
 	mixinOptions: GatewayMixinOptions = {},
 ): Partial<ServiceSchema> {
-	const { routeOptions, validationRules } = mixinOptions;
+	const { routeOptions, validationRules, showGraphiQL } = mixinOptions;
 
 	return {
 		created(this: GatewayService) {
@@ -36,7 +37,7 @@ export default function gatewayMixin(
 							const schema = this.gatewayStitcher.stitch();
 
 							this.requestHandler = new RequestHandler(schema, {
-								showGraphiQL: true,
+								showGraphiQL,
 								validationRules,
 							});
 							this.rebuildSchema = false;


### PR DESCRIPTION
This PR adds a new property to the GatewayMixin options `showGraphiQL`.  Setting this to `true` will force GraphiQL to display while setting it to `false` will force GraphiQL _not_ to display.  If this option is not provided, GraphiQL will be rendered conditionally based upon the `NODE_ENV` environment variable.  If that environment variable is set to `production` then GraphiQL will not render, otherwise it will render.