### PR TITLE
Allow introspection to be disabled

### DIFF
--- a/src/classes/GraphQLExecutor.ts
+++ b/src/classes/GraphQLExecutor.ts
@@ -1,5 +1,5 @@
 import type { GraphQLSchema, ExecutionResult, ValidationRule } from 'graphql';
-import { Source, execute, parse, getOperationAST, specifiedRules, validate } from 'graphql';
+import { Source, execute, parse, getOperationAST, validate } from 'graphql';
 import httpError from 'http-errors';
 import type { Context } from 'moleculer';
 
@@ -26,10 +26,7 @@ class GraphQLExecutor {
 		const documentAST = parse(new Source(query, 'GraphQL request'));
 		const operationAST = getOperationAST(documentAST, operationName);
 
-		const validationErrors = validate(this.schema, documentAST, [
-			...validationRules,
-			...specifiedRules,
-		]);
+		const validationErrors = validate(this.schema, documentAST, validationRules);
 
 		if (validationErrors.length > 0) {
 			// Return 400: Bad Request if any validation errors exist.

--- a/src/mixins/gatewayMixin.ts
+++ b/src/mixins/gatewayMixin.ts
@@ -14,6 +14,7 @@ interface GatewayService extends Service {
 }
 
 export interface GatewayMixinOptions {
+	introspection?: boolean;
 	routeOptions?: Route;
 	showGraphiQL?: boolean;
 	validationRules?: readonly ValidationRule[];
@@ -22,7 +23,7 @@ export interface GatewayMixinOptions {
 export default function gatewayMixin(
 	mixinOptions: GatewayMixinOptions = {},
 ): Partial<ServiceSchema> {
-	const { routeOptions, validationRules, showGraphiQL } = mixinOptions;
+	const { introspection, routeOptions, validationRules, showGraphiQL } = mixinOptions;
 
 	return {
 		created(this: GatewayService) {
@@ -37,6 +38,7 @@ export default function gatewayMixin(
 							const schema = this.gatewayStitcher.stitch();
 
 							this.requestHandler = new RequestHandler(schema, {
+								introspection,
 								showGraphiQL,
 								validationRules,
 							});

--- a/src/validationRules/disableIntrospectionRule.ts
+++ b/src/validationRules/disableIntrospectionRule.ts
@@ -1,0 +1,17 @@
+import type { ValidationContext, ValidationRule } from 'graphql';
+import { GraphQLError } from 'graphql';
+
+const disableIntrospectionRule: ValidationRule = (context: ValidationContext) => ({
+	Field(node) {
+		if (node.name.value === '__schema' || node.name.value === '__type') {
+			context.reportError(
+				new GraphQLError(
+					'GraphQL introspection is not allowed, but the query contained __schema or __type',
+					[node],
+				),
+			);
+		}
+	},
+});
+
+export default disableIntrospectionRule;

--- a/src/validationRules/index.ts
+++ b/src/validationRules/index.ts
@@ -1,0 +1,1 @@
+export { default as disableIntrospectionRule } from './disableIntrospectionRule';


### PR DESCRIPTION
This PR adds a new property to the GatewayMixin options `introspection`.  Setting this to `true` will enable GraphQL introspection queries while setting it to `false` will disable GraphQL introspection queries.  If this option is not provided, introspection will be disabled if the `NODE_ENV` environment variable is set to `production`, otherwise it will be enabled.

If introspection is disabled for any reason (explicit or implicit) then GraphiQL will not be shown regardless if it was enabled in the mixin options.