### PR TITLE
Allow providing a context factory to gateway and service mixins

### DIFF
--- a/examples/post/post.service.ts
+++ b/examples/post/post.service.ts
@@ -40,16 +40,16 @@ class PostService extends Service {
 					typeDefs,
 					resolvers: {
 						Author: {
-							posts: (parent: PostAuthor, args, context: Context) => {
-								context.broker.logger.debug('Executing Author.posts resolver');
+							posts: (parent: PostAuthor, args, context) => {
+								context.$ctx.broker.logger.debug('Executing Author.posts resolver');
 								return posts.filter((post) => {
 									return parent.id === post.authorId;
 								});
 							},
 						},
 						Post: {
-							author: (parent: Post, args, context: Context): PostAuthor => {
-								context.broker.logger.debug('Executing Post.author resolver');
+							author: (parent: Post, args, context): PostAuthor => {
+								context.$ctx.broker.logger.debug('Executing Post.author resolver');
 								return { id: parent.authorId };
 							},
 							error: (): never => {
@@ -60,9 +60,9 @@ class PostService extends Service {
 							postAuthorById: (
 								parent: unknown,
 								args: { authorIds: string[] },
-								context: Context,
+								context,
 							): PostAuthor[] => {
-								context.broker.logger.debug('Executing Query.postAuthorById resolver');
+								context.$ctx.broker.logger.debug('Executing Query.postAuthorById resolver');
 								const { authorIds } = args;
 
 								return authorIds.map((id: string) => {

--- a/src/classes/GatewayStitcher.ts
+++ b/src/classes/GatewayStitcher.ts
@@ -5,6 +5,7 @@ import type { Executor, ExecutionResult } from '@graphql-tools/utils';
 import type { GraphQLSchema } from 'graphql';
 import { print, buildSchema } from 'graphql';
 import type { Context, Service, ServiceSchema, ServiceSettingSchema } from 'moleculer';
+import type { GraphQLContext } from 'src/factories';
 import type { GraphQLRequest, GraphQLServiceSettings } from '../mixins/serviceMixin';
 import { buildFullActionName } from '../utils';
 
@@ -60,7 +61,9 @@ class GatewayStitcher {
 		});
 	}
 
-	private makeRemoteExecutor(serviceSchema: ServiceSchema): Executor<Context> {
+	private makeRemoteExecutor<TGraphQLContext extends GraphQLContext>(
+		serviceSchema: ServiceSchema,
+	): Executor<TGraphQLContext> {
 		const { name: serviceName, version } = serviceSchema;
 
 		const actionName = buildFullActionName(serviceName, '$handleGraphQLRequest', version);
@@ -78,7 +81,7 @@ class GatewayStitcher {
 
 			const query = typeof document === 'string' ? document : print(document);
 
-			const result = await context.call<ExecutionResult, GraphQLRequest>(actionName, {
+			const result = await context.$ctx.call<ExecutionResult, GraphQLRequest>(actionName, {
 				query,
 				// @ts-ignore: TODO
 				variables,

--- a/src/classes/GraphQLExecutor.ts
+++ b/src/classes/GraphQLExecutor.ts
@@ -1,7 +1,7 @@
 import type { GraphQLSchema, ExecutionResult, ValidationRule } from 'graphql';
 import { Source, execute, parse, getOperationAST, validate } from 'graphql';
 import httpError from 'http-errors';
-import type { Context } from 'moleculer';
+import type { GraphQLContext } from '../factories';
 
 interface ExecuteOptions {
 	validationRules?: readonly ValidationRule[];
@@ -14,8 +14,8 @@ class GraphQLExecutor {
 		this.schema = schema;
 	}
 
-	public async execute(
-		ctx: Context,
+	public async execute<TGraphQLContext extends GraphQLContext>(
+		graphQLContext: TGraphQLContext,
 		query: string,
 		variables: Readonly<Record<string, unknown>> | null,
 		operationName: string | null,
@@ -38,7 +38,7 @@ class GraphQLExecutor {
 		const result = await execute({
 			schema: this.schema,
 			document: documentAST,
-			contextValue: ctx,
+			contextValue: graphQLContext,
 			variableValues: variables,
 			operationName,
 		});

--- a/src/classes/RequestParser.ts
+++ b/src/classes/RequestParser.ts
@@ -81,7 +81,7 @@ class RequestParser {
 			return { query: body };
 		}
 
-		// Already parsed body we didn't recognise? Parse nothing.
+		// Already parsed body we didn't recognize? Parse nothing.
 		if (body != null) {
 			return {};
 		}

--- a/src/factories/contextFactory.ts
+++ b/src/factories/contextFactory.ts
@@ -1,0 +1,15 @@
+import type { Context } from 'moleculer';
+
+export interface GraphQLContext {
+	$ctx: Context;
+}
+
+export type GraphQLContextFactory<TGraphQLContext extends GraphQLContext = GraphQLContext> = (
+	ctx: Context,
+) => Promise<TGraphQLContext>;
+
+const contextFactory: GraphQLContextFactory = (ctx: Context) => {
+	return Promise.resolve({ $ctx: ctx });
+};
+
+export default contextFactory;

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,0 +1,1 @@
+export { default as contextFactory, GraphQLContextFactory, GraphQLContext } from './contextFactory';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './mixins';
+export type { GraphQLContext, GraphQLContextFactory } from './factories';


### PR DESCRIPTION
**Breaking Change**

This PR allows for specification of an asynchronous context factory to both the gateway and service mixins so that a consumer of those mixins can construct their own GraphQL Context objects.  This can be provided via a new `contextFactory` option.  The signature of this factory is:

```ts
interface GraphQLContext {
  $ctx: Context;
}

type GraphQLContextFactory<TGraphQLContext extends GraphQLContext = GraphQLContext> = (
  ctx: Context,
) => Promise<TGraphQLContext>;
```

This alters the existing GraphQL Context which was previously the same as the moleculer context.  Instead, a `$ctx` property will be present on the GraphQL Context which contains the moleculer context.  Any consumer providing a context factory will need to ensure that this `$ctx` property is added to the resulting object from the provided context factory.