### PR TITLE
Relocate execution of context factory

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,17 @@
+{
+  "language": "en",
+  "ignorePaths": [
+    ".eslintcache",
+    "node_modules",
+    "coverage",
+
+    "cspell.json",
+    "package.json",
+    "package-lock.json",
+    "tsconfig.json"
+  ],
+  "words": [
+    "graphiql",
+    "moleculer"
+  ]
+}

--- a/src/classes/RequestHandler.ts
+++ b/src/classes/RequestHandler.ts
@@ -26,8 +26,6 @@ interface RequestHandlerOptions {
 export type Request = IncomingRequest & { url: string; body?: unknown };
 
 class RequestHandler {
-	private contextFactory: GraphQLContextFactory;
-
 	private requestParser: RequestParser = new RequestParser();
 
 	private graphQLExecutor: GraphQLExecutor;
@@ -45,8 +43,7 @@ class RequestHandler {
 		contextFactory: GraphQLContextFactory,
 		opts: RequestHandlerOptions = {},
 	) {
-		this.contextFactory = contextFactory;
-		this.graphQLExecutor = new GraphQLExecutor(schema);
+		this.graphQLExecutor = new GraphQLExecutor(schema, contextFactory);
 
 		const {
 			showGraphiQL,
@@ -82,9 +79,7 @@ class RequestHandler {
 				throw httpError(400, 'Must provide query string.');
 			}
 
-			const graphQLContext = await this.contextFactory(req.$ctx);
-
-			result = await this.graphQLExecutor.execute(graphQLContext, query, variables, operationName, {
+			result = await this.graphQLExecutor.execute(req.$ctx, query, variables, operationName, {
 				validationRules: this.validationRules,
 			});
 		} catch (rawError: unknown) {

--- a/src/mixins/serviceMixin.ts
+++ b/src/mixins/serviceMixin.ts
@@ -54,16 +54,14 @@ export default function serviceMixin<TGraphQLContext extends GraphQLContext = Gr
 				subschemaConfig: defaultedSubschemaConfig,
 			};
 
-			this.graphQLExecutor = new GraphQLExecutor(schema);
+			this.graphQLExecutor = new GraphQLExecutor(schema, contextFactory);
 		},
 
 		actions: {
 			async $handleGraphQLRequest(this: GraphQLService, ctx: Context<GraphQLRequest>) {
 				const { query, variables, operationName } = ctx.params;
 
-				const graphQLContext = await contextFactory(ctx);
-
-				return this.graphQLExecutor.execute(graphQLContext, query, variables, operationName);
+				return this.graphQLExecutor.execute(ctx, query, variables, operationName);
 			},
 		},
 	};


### PR DESCRIPTION
This PR tweaks where the context factory gets executed, reducing the dependency on the callers to have executed the factory and instead allowing the executor to handle the factory's execution.