### PR TITLE
Add mutation examples

### DIFF
--- a/examples/author/author.graphql
+++ b/examples/author/author.graphql
@@ -8,3 +8,11 @@ type Query {
 
 	authorsById(ids: [ID!]): [Author] @merge(keyField: "id")
 }
+
+input AuthorCreateInput {
+	name: String!
+}
+
+type Mutation {
+	authorCreate(author: AuthorCreateInput): Author!
+}

--- a/examples/author/author.service.ts
+++ b/examples/author/author.service.ts
@@ -3,13 +3,17 @@ import path from 'path';
 import type { Context, ServiceBroker } from 'moleculer';
 import { Service } from 'moleculer';
 import { serviceMixin } from '../../src';
+import type {
+	Author,
+	AuthorByIdParams,
+	AuthorByIdResult,
+	AuthorsByIdParams,
+	AuthorsByIdResult,
+	AuthorCreateParams,
+	AuthorCreateResult,
+} from './types';
 
 const typeDefs = readFileSync(path.join(__dirname, './author.graphql'), 'utf8');
-
-interface Author {
-	id: string;
-	name: string;
-}
 
 const authors: Author[] = [
 	{
@@ -36,29 +40,57 @@ class AuthorService extends Service {
 
 			actions: {
 				authorById: {
-					handler(ctx: Context<{ id: string }>) {
+					handler(ctx: Context<AuthorByIdParams>): AuthorByIdResult {
 						const { id } = ctx.params;
 
 						const result = authors.find((author) => author.id === id);
 
-						return result;
+						return result ?? null;
 					},
 					graphql: {
 						query: 'authorById',
 					},
 				},
+
 				authorsById: {
-					handler(ctx: Context<{ ids: string[] }>) {
+					handler(ctx: Context<AuthorsByIdParams>): AuthorsByIdResult {
 						const { ids } = ctx.params;
 
-						const result = authors.filter((author) => {
-							return ids.includes(author.id);
+						const result = ids.map((id) => {
+							return authors.find((author) => author.id === id) ?? null;
 						});
 
 						return result;
 					},
 					graphql: {
 						query: 'authorsById',
+					},
+				},
+
+				authorCreate: {
+					handler(ctx: Context<AuthorCreateParams>): AuthorCreateResult {
+						const {
+							author: { name },
+						} = ctx.params;
+
+						const nextId = String(
+							Math.max(
+								...authors.map(({ id }) => {
+									return Number(id);
+								}),
+							) + 1,
+						);
+
+						const author: Author = {
+							id: nextId,
+							name,
+						};
+
+						authors.push(author);
+						return author;
+					},
+					graphql: {
+						mutation: 'authorCreate',
 					},
 				},
 			},

--- a/examples/author/types.ts
+++ b/examples/author/types.ts
@@ -1,0 +1,22 @@
+export interface Author {
+	id: string;
+	name: string;
+}
+
+export interface AuthorByIdParams {
+	id: string;
+}
+export type AuthorByIdResult = Author | null;
+
+export interface AuthorsByIdParams {
+	ids: string[];
+}
+export type AuthorsByIdResult = (Author | null)[];
+
+export interface AuthorCreate {
+	name: string;
+}
+export interface AuthorCreateParams {
+	author: AuthorCreate;
+}
+export type AuthorCreateResult = Author;

--- a/examples/post/post.graphql
+++ b/examples/post/post.graphql
@@ -17,3 +17,12 @@ type Query {
 
 	postAuthorById(authorIds: [ID!]!): [Author]! @merge(keyField: "id")
 }
+
+input PostCreateInput {
+	authorId: String!
+	message: String!
+}
+
+type Mutation {
+	postCreate(post: PostCreateInput): Post!
+}

--- a/examples/post/types.ts
+++ b/examples/post/types.ts
@@ -1,0 +1,28 @@
+export interface Post {
+	id: string;
+	authorId: string;
+	message: string;
+}
+
+export interface PostAuthor {
+	id: string;
+}
+
+export interface PostByIdParams {
+	id: string;
+}
+export type PostByIdResult = Post | null;
+
+export interface PostsByIdParams {
+	ids: string[];
+}
+export type PostsByIdResult = (Post | null)[];
+
+export interface PostCreate {
+	authorId: string;
+	message: string;
+}
+export interface PostCreateParams {
+	post: PostCreate;
+}
+export type PostCreateResult = Post;


### PR DESCRIPTION
This PR improves the examples to include examples of mutations -- `postCreate` and `authorCreate`.

Note: Since the "database" is merely a local array, the networking examples will not function well with mutations since each replica will have its own local copy of the "database".