### PR TITLE
Regenerate package lock to fix problems in examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,6 @@
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.16.0"
-      },
-      "dependencies": {
-        "@babel/highlight": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.15.7",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        }
       }
     },
     "@babel/generator": {
@@ -142,12 +129,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -275,9 +262,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -315,40 +302,6 @@
         "@graphql-tools/utils": "^8.5.1",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/batch-execute": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-          "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.1.tgz",
-          "integrity": "sha512-Oz1DYXmAKPKgHNsFnflg+CXKRVoPJI3AGRkcaRR0kA/4VWlMiKonL2O0BZdoRd0IbtZimBeQCrDEb5TikjIv0g==",
-          "requires": {
-            "@graphql-tools/batch-execute": "^8.3.1",
-            "@graphql-tools/schema": "^8.3.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/batch-execute": {
@@ -360,16 +313,6 @@
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/code-file-loader": {
@@ -383,17 +326,6 @@
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/delegate": {
@@ -407,16 +339,6 @@
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/graphql-file-loader": {
@@ -430,17 +352,6 @@
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/graphql-tag-pluck": {
@@ -454,17 +365,6 @@
         "@babel/types": "7.15.6",
         "@graphql-tools/utils": "^8.5.1",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/import": {
@@ -476,17 +376,6 @@
         "@graphql-tools/utils": "8.5.1",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/json-file-loader": {
@@ -499,17 +388,6 @@
         "globby": "^11.0.3",
         "tslib": "~2.3.0",
         "unixify": "^1.0.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/load": {
@@ -522,39 +400,6 @@
         "@graphql-tools/utils": "^8.5.1",
         "p-limit": "3.1.0",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/merge": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.1.tgz",
-          "integrity": "sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "tslib": "~2.3.0"
-          }
-        },
-        "@graphql-tools/schema": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.1.tgz",
-          "integrity": "sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/merge": "^8.2.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/merge": {
@@ -564,16 +409,6 @@
       "requires": {
         "@graphql-tools/utils": "^8.5.1",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/schema": {
@@ -585,16 +420,6 @@
         "@graphql-tools/utils": "^8.5.1",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/stitch": {
@@ -609,40 +434,6 @@
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/batch-execute": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-          "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.1.tgz",
-          "integrity": "sha512-Oz1DYXmAKPKgHNsFnflg+CXKRVoPJI3AGRkcaRR0kA/4VWlMiKonL2O0BZdoRd0IbtZimBeQCrDEb5TikjIv0g==",
-          "requires": {
-            "@graphql-tools/batch-execute": "^8.3.1",
-            "@graphql-tools/schema": "^8.3.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/stitching-directives": {
@@ -653,16 +444,6 @@
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "tslib": "~2.3.0"
-      },
-      "dependencies": {
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@graphql-tools/url-loader": {
@@ -692,78 +473,6 @@
         "valid-url": "1.0.9",
         "value-or-promise": "1.0.11",
         "ws": "8.2.3"
-      },
-      "dependencies": {
-        "@graphql-tools/batch-execute": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-          "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.1.tgz",
-          "integrity": "sha512-Oz1DYXmAKPKgHNsFnflg+CXKRVoPJI3AGRkcaRR0kA/4VWlMiKonL2O0BZdoRd0IbtZimBeQCrDEb5TikjIv0g==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/batch-execute": "^8.3.1",
-            "@graphql-tools/schema": "^8.3.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/merge": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.1.tgz",
-          "integrity": "sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "tslib": "~2.3.0"
-          }
-        },
-        "@graphql-tools/schema": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.1.tgz",
-          "integrity": "sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/merge": "^8.2.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "dev": true,
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        },
-        "@graphql-tools/wrap": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-8.3.1.tgz",
-          "integrity": "sha512-vcbxawe4gFLuzvT9/CrZhauv9Rk9bMqZIwxgS/w3DWN+G7o6+fNxIv6LYt0acE5+rHJOF6+r3lX/SgFgPyoWww==",
-          "dev": true,
-          "requires": {
-            "@graphql-tools/delegate": "^8.4.1",
-            "@graphql-tools/schema": "^8.3.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        }
       }
     },
     "@graphql-tools/utils": {
@@ -784,40 +493,6 @@
         "@graphql-tools/utils": "^8.5.1",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/batch-execute": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.3.1.tgz",
-          "integrity": "sha512-63kHY8ZdoO5FoeDXYHnAak1R3ysMViMPwWC2XUblFckuVLMUPmB2ONje8rjr2CvzWBHAW8c1Zsex+U3xhKtGIA==",
-          "requires": {
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/delegate": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.1.tgz",
-          "integrity": "sha512-Oz1DYXmAKPKgHNsFnflg+CXKRVoPJI3AGRkcaRR0kA/4VWlMiKonL2O0BZdoRd0IbtZimBeQCrDEb5TikjIv0g==",
-          "requires": {
-            "@graphql-tools/batch-execute": "^8.3.1",
-            "@graphql-tools/schema": "^8.3.1",
-            "@graphql-tools/utils": "^8.5.1",
-            "dataloader": "2.0.0",
-            "tslib": "~2.3.0",
-            "value-or-promise": "1.0.11"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.1.tgz",
-          "integrity": "sha512-V/OQVpj+Z05qW9ZdlJWSKzREYlgGEq+juV+pUy3JO9jI+sZo/W3oncuW9+1awwp/RkL0aZ9RgjL+XYOgCsmOLw==",
-          "requires": {
-            "tslib": "~2.3.0"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -2188,9 +1863,9 @@
           }
         },
         "globals": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -2404,9 +2079,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -2421,9 +2096,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }


### PR DESCRIPTION
After dependabot updates, the examples were not properly child resolving.  Regenerating package-lock fresh fixed the problem.