### PR TITLE
Allow custom directives

### DIFF
--- a/examples/author/author.graphql
+++ b/examples/author/author.graphql
@@ -1,6 +1,7 @@
 type Author @canonical {
 	id: ID!
 	name: String!
+	email: String! @lower
 }
 
 type Query {

--- a/examples/author/author.service.ts
+++ b/examples/author/author.service.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { Context, ServiceBroker } from 'moleculer';
 import { Service } from 'moleculer';
 import { serviceMixin } from '../../src';
+import { lowerDirectiveFactory } from '../directives';
 import type {
 	Author,
 	AuthorByIdParams,
@@ -19,12 +20,17 @@ const authors: Author[] = [
 	{
 		id: '1',
 		name: 'O.J. Simpson',
+		email: 'OJ@THEJUICE.COM',
 	},
 	{
 		id: '2',
 		name: 'John Steinbeck',
+		email: 'GrapesOfWrathLover77@gmail.com',
 	},
 ];
+
+const { typeDefs: lowerDirectiveTypeDefs, transformer: lowerDirectiveTransformer } =
+	lowerDirectiveFactory('lower');
 
 class AuthorService extends Service {
 	public constructor(broker: ServiceBroker) {
@@ -34,7 +40,11 @@ class AuthorService extends Service {
 
 			mixins: [
 				serviceMixin({
-					typeDefs,
+					typeDefs: /* GraphQL */ `
+						${lowerDirectiveTypeDefs}
+						${typeDefs}
+					`,
+					schemaDirectiveTransformers: [lowerDirectiveTransformer],
 				}),
 			],
 
@@ -70,7 +80,7 @@ class AuthorService extends Service {
 				authorCreate: {
 					handler(ctx: Context<AuthorCreateParams>): AuthorCreateResult {
 						const {
-							author: { name },
+							author: { name, email },
 						} = ctx.params;
 
 						const nextId = String(
@@ -84,6 +94,7 @@ class AuthorService extends Service {
 						const author: Author = {
 							id: nextId,
 							name,
+							email,
 						};
 
 						authors.push(author);

--- a/examples/author/types.ts
+++ b/examples/author/types.ts
@@ -1,6 +1,7 @@
 export interface Author {
 	id: string;
 	name: string;
+	email: string;
 }
 
 export interface AuthorByIdParams {
@@ -15,6 +16,7 @@ export type AuthorsByIdResult = (Author | null)[];
 
 export interface AuthorCreate {
 	name: string;
+	email: string;
 }
 export interface AuthorCreateParams {
 	author: AuthorCreate;

--- a/examples/directives/index.ts
+++ b/examples/directives/index.ts
@@ -1,0 +1,2 @@
+export { default as lowerDirectiveFactory } from './lower';
+export { default as upperDirectiveFactory } from './upper';

--- a/examples/directives/lower.ts
+++ b/examples/directives/lower.ts
@@ -1,0 +1,29 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
+import { defaultFieldResolver } from 'graphql';
+import type { DirectiveFactoryResult } from '../types';
+
+const lowerDirectiveFactory = (directiveName: string): DirectiveFactoryResult => {
+	return {
+		typeDefs: /* GraphQL */ `directive @${directiveName} on FIELD_DEFINITION`,
+		transformer: (schema) =>
+			mapSchema(schema, {
+				[MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+					const lowerDirective = getDirective(schema, fieldConfig, directiveName)?.[0];
+
+					if (lowerDirective == null) {
+						return undefined;
+					}
+
+					const { resolve = defaultFieldResolver } = fieldConfig;
+					// eslint-disable-next-line no-param-reassign
+					fieldConfig.resolve = async (source, args, context, info) => {
+						const result = await resolve(source, args, context, info);
+						return typeof result === 'string' ? result.toLowerCase() : result;
+					};
+					return fieldConfig;
+				},
+			}),
+	};
+};
+
+export default lowerDirectiveFactory;

--- a/examples/directives/upper.ts
+++ b/examples/directives/upper.ts
@@ -1,0 +1,29 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
+import { defaultFieldResolver } from 'graphql';
+import type { DirectiveFactoryResult } from '../types';
+
+const upperDirectiveFactory = (directiveName: string): DirectiveFactoryResult => {
+	return {
+		typeDefs: /* GraphQL */ `directive @${directiveName} on FIELD_DEFINITION`,
+		transformer: (schema) =>
+			mapSchema(schema, {
+				[MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+					const upperDirective = getDirective(schema, fieldConfig, directiveName)?.[0];
+
+					if (upperDirective == null) {
+						return undefined;
+					}
+
+					const { resolve = defaultFieldResolver } = fieldConfig;
+					// eslint-disable-next-line no-param-reassign
+					fieldConfig.resolve = async (source, args, context, info) => {
+						const result = await resolve(source, args, context, info);
+						return typeof result === 'string' ? result.toUpperCase() : result;
+					};
+					return fieldConfig;
+				},
+			}),
+	};
+};
+
+export default upperDirectiveFactory;

--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,0 +1,6 @@
+import type { GraphQLSchema } from 'graphql';
+
+export interface DirectiveFactoryResult {
+	typeDefs: string;
+	transformer: (schema: GraphQLSchema) => GraphQLSchema;
+}

--- a/src/classes/index.ts
+++ b/src/classes/index.ts
@@ -6,4 +6,4 @@ export {
 } from './GraphQLExecutor';
 export { default as RequestHandler, Request } from './RequestHandler';
 export { default as requestParser } from './RequestParser';
-export { default as SchemaBuilder } from './SchemaBuilder';
+export { default as SchemaBuilder, SchemaDirectiveTransformer } from './SchemaBuilder';


### PR DESCRIPTION
This PR allows passing schema directive transformers to the `serviceMixin` via a new option `schemaDirectiveTransformers` which accepts an array of transformer functions as specified by https://www.graphql-tools.com/docs/schema-directives.

`lower` and `upper` directives have been added to the examples and the `@lower` directive is being used to set email addresses of authors to lowercase.