### PR TITLE
Disable dependabot in favor of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: "npm"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "00:00"
-  open-pull-requests-limit: 25


### PR DESCRIPTION
This PR disables dependabot as renovate has been activated instead.