### PR TITLE
Modify renovate.json to only pin dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":pinOnlyDevDependencies"
   ]
 }


### PR DESCRIPTION
Update renovate configuration so that only dev dependencies are pinned.