### PR TITLE
Try to improve renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,31 @@
 {
   "extends": [
     "config:base",
-    ":preserveSemverRanges",
+    ":onlyNpm",
+    ":automergeTypes",
+    ":automergeMinor",
+    ":rebaseStalePrs",
+    ":prHourlyLimit4",
     ":label(dependencies)"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "widen"
+    }
   ]
 }


### PR DESCRIPTION
This PR improves the renovate configuration to try and bump dependencies (while keeping devDependencies pinned and peerDependencies widened) and sets up some automerge rules.