### PR TITLE
Do not automatically bump engines level

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,12 @@
         "peerDependencies"
       ],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchDepTypes": [
+        "engines"
+      ],
+      "rangeStrategy": "auto"
     }
   ]
 }


### PR DESCRIPTION
Renovate is currently creating PRs to automatically bump versions in the engines property.  This PR should suppress that behavior.