### PR TITLE
Fix two deprecated methods

### DIFF
--- a/src/classes/RequestParser.ts
+++ b/src/classes/RequestParser.ts
@@ -1,4 +1,3 @@
-import querystring from 'querystring';
 import { URLSearchParams } from 'url';
 import type { Gunzip, Inflate } from 'zlib';
 import zlib from 'zlib';
@@ -100,8 +99,10 @@ class RequestParser {
 					}
 				}
 				throw httpError(400, 'POST body sent invalid JSON.');
-			case 'application/x-www-form-urlencoded':
-				return querystring.parse(rawBody);
+			case 'application/x-www-form-urlencoded': {
+				const params = new URLSearchParams(rawBody);
+				return Object.fromEntries(params);
+			}
 			default:
 				return {};
 		}

--- a/src/validationRules/disableIntrospectionRule.ts
+++ b/src/validationRules/disableIntrospectionRule.ts
@@ -8,7 +8,7 @@ const disableIntrospectionRule: ValidationRule = (context: ValidationContext) =>
 			context.reportError(
 				new GraphQLError(
 					'GraphQL introspection is not allowed, but the query contained __schema or __type',
-					[node],
+					{ nodes: node },
 				),
 			);
 		}


### PR DESCRIPTION
This PR updates two deprecation warnings:
- `querystring.parse` updated to use `URLSearchParams`
- `GraphQLError` updated to use the options object overload