### PR TITLE
Increase minimum node version to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/shawnmcknight/moleculer-graphql#readme",
   "devDependencies": {
     "@graphql-tools/delegate": "9.0.17",
-    "@tsconfig/node12": "1.0.11",
+    "@tsconfig/node16": "1.0.3",
     "@types/accepts": "1.3.5",
     "@types/content-type": "1.1.5",
     "@types/fs-extra": "9.0.13",
@@ -92,7 +92,7 @@
     "moleculer-web": "^0.10.0"
   },
   "engines": {
-    "node": ">=12.11.0"
+    "node": ">=16.18.0"
   },
   "packageManager": "pnpm@7.18.0",
   "types": "./index.d.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ specifiers:
   '@graphql-tools/stitch': ^8.7.1
   '@graphql-tools/stitching-directives': ^2.3.1
   '@graphql-tools/utils': ^8.9.0
-  '@tsconfig/node12': 1.0.11
+  '@tsconfig/node16': 1.0.3
   '@types/accepts': 1.3.5
   '@types/content-type': 1.1.5
   '@types/fs-extra': 9.0.13
@@ -59,7 +59,7 @@ dependencies:
 
 devDependencies:
   '@graphql-tools/delegate': 9.0.17_graphql@16.6.0
-  '@tsconfig/node12': 1.0.11
+  '@tsconfig/node16': 1.0.3
   '@types/accepts': 1.3.5
   '@types/content-type': 1.1.5
   '@types/fs-extra': 9.0.13

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {


### PR DESCRIPTION
This PR updates the minimum node version to v16.  v12 was the previous target but that is no longer LTS.  v14 is scheduled to be out of LTS by April which is likely before an official release of this package will occur.  At that time the oldest LTS release of Node will be 16, so support is targeting that version.