### PR TITLE
Add eslint-plugin-deprecation and turn on warning level

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -39,6 +39,7 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-deprecation": "1.3.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.6"
   }

--- a/internal/eslint-config/.lintstagedrc.cjs
+++ b/internal/eslint-config/.lintstagedrc.cjs
@@ -1,4 +1,0 @@
-module.exports = {
-  '*.{js,ts}': 'eslint --cache --fix',
-  '*': 'prettier --ignore-unknown --write',
-};

--- a/internal/eslint-config/index.js
+++ b/internal/eslint-config/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
 	env: { es2021: true, node: true, 'jest/globals': true },
 
-	plugins: ['jest'],
+	plugins: ['jest', 'deprecation'],
 
 	ignorePatterns: ['node_modules', 'dist', 'coverage', '**/*.d.ts', '!.*.js', '!.*.cjs', '!.*.mjs'],
 
@@ -110,6 +110,9 @@ module.exports = {
 		// overrides @typescript-eslint/recommended -- '@typescript-eslint/no-unused-vars': 'warn'
 		// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts
 		'@typescript-eslint/no-unused-vars': 'error',
+
+		// warn on use of deprecated code
+		'deprecation/deprecation': 'warn',
 	},
 
 	overrides: [

--- a/internal/eslint-config/package.json
+++ b/internal/eslint-config/package.json
@@ -17,6 +17,7 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-deprecation": "1.3.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.6"
   },
@@ -27,6 +28,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-deprecation": "^1.3.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.6"
   }

--- a/packages/moleculer-graphql/package.json
+++ b/packages/moleculer-graphql/package.json
@@ -70,6 +70,7 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-plugin-deprecation": "1.3.3",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.6",
     "fs-extra": "11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0
       eslint-config-airbnb-typescript: 17.0.0
       eslint-config-prettier: 8.5.0
+      eslint-plugin-deprecation: 1.3.3
       eslint-plugin-import: 2.26.0
       eslint-plugin-jest: 27.1.6
       graphql: ^16.6.0
@@ -64,6 +65,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0_lt3hqehuojhfcbzgzqfngbtmrq
       eslint-config-airbnb-typescript: 17.0.0_plzmdonoqypich7rnhvywvgwqe
       eslint-config-prettier: 8.5.0_eslint@8.29.0
+      eslint-plugin-deprecation: 1.3.3_eslint@8.29.0
       eslint-plugin-import: 2.26.0_jx43xxcguvnqqmtmaaygwl7cmu
       eslint-plugin-jest: 27.1.6_az5lmaeuvswqhyu3aute3pgqim
 
@@ -75,6 +77,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0
       eslint-config-airbnb-typescript: 17.0.0
       eslint-config-prettier: 8.5.0
+      eslint-plugin-deprecation: 1.3.3
       eslint-plugin-import: 2.26.0
       eslint-plugin-jest: 27.1.6
     devDependencies:
@@ -84,6 +87,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0_lt3hqehuojhfcbzgzqfngbtmrq
       eslint-config-airbnb-typescript: 17.0.0_plzmdonoqypich7rnhvywvgwqe
       eslint-config-prettier: 8.5.0_eslint@8.29.0
+      eslint-plugin-deprecation: 1.3.3_eslint@8.29.0
       eslint-plugin-import: 2.26.0_jx43xxcguvnqqmtmaaygwl7cmu
       eslint-plugin-jest: 27.1.6_az5lmaeuvswqhyu3aute3pgqim
 
@@ -120,6 +124,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0
       eslint-config-airbnb-typescript: 17.0.0
       eslint-config-prettier: 8.5.0
+      eslint-plugin-deprecation: 1.3.3
       eslint-plugin-import: 2.26.0
       eslint-plugin-jest: 27.1.6
       fs-extra: 11.1.0
@@ -161,6 +166,7 @@ importers:
       eslint-config-airbnb-base: 15.0.0_lt3hqehuojhfcbzgzqfngbtmrq
       eslint-config-airbnb-typescript: 17.0.0_plzmdonoqypich7rnhvywvgwqe
       eslint-config-prettier: 8.5.0_eslint@8.29.0
+      eslint-plugin-deprecation: 1.3.3_eslint@8.29.0
       eslint-plugin-import: 2.26.0_jx43xxcguvnqqmtmaaygwl7cmu
       eslint-plugin-jest: 27.1.6_xty5zoe3fryexrkvwwlnxcelhu
       fs-extra: 11.1.0
@@ -1153,6 +1159,19 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.46.0_eslint@8.29.0:
+    resolution: {integrity: sha512-iMnpijlNNLL+OPIzLadOYQzHsPQ2FW6Qcd5+4DpUv9lQN4Kl+AGxjv0dx+dXPgJfDpj9Q8ePlbROdKLjQydHqg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.46.0_eslint@8.29.0
+      eslint: 8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/parser/5.46.0_eslint@8.29.0:
     resolution: {integrity: sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2106,6 +2125,20 @@ packages:
       debug: 3.2.7
       eslint: 8.29.0
       eslint-import-resolver-node: 0.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-deprecation/1.3.3_eslint@8.29.0:
+    resolution: {integrity: sha512-Bbkv6ZN2cCthVXz/oZKPwsSY5S/CbgTLRG4Q2s2gpPpgNsT0uJ0dB5oLNiWzFYY8AgKX4ULxXFG1l/rDav9QFA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: ^3.7.5 || ^4.0.0
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.46.0_eslint@8.29.0
+      eslint: 8.29.0
+      tslib: 2.4.1
+      tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
This PR activates `eslint-plugin-deprecation` and turns on its rules with a warning level.  This will help uncover any use of code that is marked as deprecated and should be changed.