### PR TITLE
Switch to using workspace version of typescript

### DIFF
--- a/.vscode/moleculer-graphql.code-workspace
+++ b/.vscode/moleculer-graphql.code-workspace
@@ -27,7 +27,7 @@
   ],
   "settings": {
     "files.eol": "\n",
-    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "typescript.tsdk": "✨ @shawnmcknight\\moleculer-graphql-monorepo\\node_modules\\typescript\\lib",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
The version of TypeScript built-in to vscode (4.9.3) was triggering false positive errors that the workspace  version (4.9.4) was not reporting.  This PR changes vscode to use the workspace version instead of the built-in version.