### PR TITLE
Improve renovate configuration

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -18,14 +18,14 @@
     "typecheck": "tsc --noEmit && echo \"tsc: no typecheck errors\""
   },
   "dependencies": {
-    "@graphql-tools/utils": "^9.1.3",
+    "@graphql-tools/utils": "9.1.3",
     "@shawnmcknight/moleculer-graphql": "workspace:*",
-    "graphql": "^16.6.0",
-    "graphql-depth-limit": "^1.1.0",
-    "moleculer": "^0.14.26",
-    "moleculer-repl": "^0.7.3",
-    "moleculer-web": "^0.10.4",
-    "ts-node": "^10.9.1"
+    "graphql": "16.6.0",
+    "graphql-depth-limit": "1.1.0",
+    "moleculer": "0.14.26",
+    "moleculer-repl": "0.7.3",
+    "moleculer-web": "0.10.4",
+    "ts-node": "10.9.1"
   },
   "devDependencies": {
     "@shawnmcknight/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
 
   examples/basic:
     specifiers:
-      '@graphql-tools/utils': ^9.1.3
+      '@graphql-tools/utils': 9.1.3
       '@shawnmcknight/eslint-config': workspace:*
       '@shawnmcknight/moleculer-graphql': workspace:*
       '@shawnmcknight/tsconfig': workspace:*
@@ -38,12 +38,12 @@ importers:
       eslint-plugin-deprecation: 1.3.3
       eslint-plugin-import: 2.26.0
       eslint-plugin-jest: 27.1.6
-      graphql: ^16.6.0
-      graphql-depth-limit: ^1.1.0
-      moleculer: ^0.14.26
-      moleculer-repl: ^0.7.3
-      moleculer-web: ^0.10.4
-      ts-node: ^10.9.1
+      graphql: 16.6.0
+      graphql-depth-limit: 1.1.0
+      moleculer: 0.14.26
+      moleculer-repl: 0.7.3
+      moleculer-web: 0.10.4
+      ts-node: 10.9.1
     dependencies:
       '@graphql-tools/utils': 9.1.3_graphql@16.6.0
       '@shawnmcknight/moleculer-graphql': link:../../packages/moleculer-graphql

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
     ":onlyNpm",
@@ -8,11 +9,9 @@
     ":prHourlyLimit4",
     ":label(dependencies)"
   ],
+  "ignorePaths": ["**/node_modules/**"],
+  "rangeStrategy": "bump",
   "packageRules": [
-    {
-      "matchPackagePatterns": ["*"],
-      "rangeStrategy": "bump"
-    },
     {
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "pin"


### PR DESCRIPTION
The current renovate configuration is ignoring the `examples` folder because `config:base` specifically excludes it.  This PR makes the following changes:
* Adds the a json schema reference to renovate.json
* Sets `ignorePaths` manually to only exclude `node_modules`
* Migrates the "bump" `rangeStrategy` to be global to hopefully ensure that production dependencies are bumped
* Pins the range of production dependencies for the examples