### PR TITLE
Adjust workspace dependency ranges

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
-save-prefix=
-shell-emulator=true
+save-prefix=^
 save-workspace-protocol=rolling
+shell-emulator=true
 public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*
 public-hoist-pattern[]=@types*

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "9.1.3",
-    "@moleculer-graphql/moleculer-graphql": "workspace:*",
+    "@moleculer-graphql/moleculer-graphql": "workspace:^",
     "graphql": "16.6.0",
     "graphql-depth-limit": "1.1.0",
     "moleculer": "0.14.27",
@@ -28,8 +28,8 @@
     "ts-node": "10.9.1"
   },
   "devDependencies": {
-    "@moleculer-graphql/eslint-config": "workspace:*",
-    "@moleculer-graphql/tsconfig": "workspace:*",
+    "@moleculer-graphql/eslint-config": "workspace:^",
+    "@moleculer-graphql/tsconfig": "workspace:^",
     "@types/graphql-depth-limit": "1.1.3",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",

--- a/packages/moleculer-graphql/package.json
+++ b/packages/moleculer-graphql/package.json
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@graphql-tools/delegate": "9.0.20",
-    "@moleculer-graphql/eslint-config": "workspace:*",
-    "@moleculer-graphql/tsconfig": "workspace:*",
+    "@moleculer-graphql/eslint-config": "workspace:^",
+    "@moleculer-graphql/tsconfig": "workspace:^",
     "@types/accepts": "1.3.5",
     "@types/content-type": "1.1.5",
     "@types/fs-extra": "9.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,9 @@ importers:
   examples/basic:
     specifiers:
       '@graphql-tools/utils': 9.1.3
-      '@moleculer-graphql/eslint-config': workspace:*
-      '@moleculer-graphql/moleculer-graphql': workspace:*
-      '@moleculer-graphql/tsconfig': workspace:*
+      '@moleculer-graphql/eslint-config': workspace:^
+      '@moleculer-graphql/moleculer-graphql': workspace:^
+      '@moleculer-graphql/tsconfig': workspace:^
       '@types/graphql-depth-limit': 1.1.3
       '@typescript-eslint/eslint-plugin': 5.46.1
       '@typescript-eslint/parser': 5.46.1
@@ -103,8 +103,8 @@ importers:
       '@graphql-tools/stitch': ^8.7.32
       '@graphql-tools/stitching-directives': ^2.3.23
       '@graphql-tools/utils': ^9.1.3
-      '@moleculer-graphql/eslint-config': workspace:*
-      '@moleculer-graphql/tsconfig': workspace:*
+      '@moleculer-graphql/eslint-config': workspace:^
+      '@moleculer-graphql/tsconfig': workspace:^
       '@types/accepts': 1.3.5
       '@types/content-type': 1.1.5
       '@types/fs-extra': 9.0.13


### PR DESCRIPTION
This PR adjusts all workspace dependencies so they have `^` range configurations by default.  This should ensure that when workspaces are linked during publish they will have `^` range dependencies in the final `package.json`.