### PR TITLE
Remove the version from the monorepo root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@moleculer-graphql/moleculer-graphql-monorepo",
   "private": true,
-  "version": "0.0.0-alpha.4",
   "description": "Monorepo for moleculer-graphql",
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
The monorepo root `package.json` currently has a version.  This is not needed since each package would be published independently.  This PR removes the version.