### PR TITLE
Remove private from publishables

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@moleculer-graphql/context",
   "description": "Context helpers for moleculer-graphql",
-  "private": true,
   "version": "0.0.0-alpha.4",
   "publishConfig": {
     "directory": "dist"

--- a/packages/context/scripts/copy-files.ts
+++ b/packages/context/scripts/copy-files.ts
@@ -13,7 +13,6 @@ const createPackageFile = async (): Promise<void> => {
 
 	const newPackageData = {
 		...packageDataOther,
-		private: false,
 		main: './index.js',
 		types: './index.d.ts',
 	};

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@moleculer-graphql/gateway",
   "description": "Gateway mixin for moleculer-graphql used for Moleculer microservices",
-  "private": true,
   "version": "0.0.0-alpha.4",
   "publishConfig": {
     "directory": "dist"

--- a/packages/gateway/scripts/copy-files.ts
+++ b/packages/gateway/scripts/copy-files.ts
@@ -13,7 +13,6 @@ const createPackageFile = async (): Promise<void> => {
 
 	const newPackageData = {
 		...packageDataOther,
-		private: false,
 		main: './index.js',
 		types: './index.d.ts',
 	};

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@moleculer-graphql/service",
   "description": "Service mixin for moleculer-graphql used for Moleculer microservices",
-  "private": true,
   "version": "0.0.0-alpha.4",
   "publishConfig": {
     "directory": "dist"

--- a/packages/service/scripts/copy-files.ts
+++ b/packages/service/scripts/copy-files.ts
@@ -13,7 +13,6 @@ const createPackageFile = async (): Promise<void> => {
 
 	const newPackageData = {
 		...packageDataOther,
-		private: false,
 		main: './index.js',
 		types: './index.d.ts',
 	};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@moleculer-graphql/utils",
   "description": "Utilities for moleculer-graphql",
-  "private": true,
   "version": "0.0.0-alpha.4",
   "publishConfig": {
     "directory": "dist"

--- a/packages/utils/scripts/copy-files.ts
+++ b/packages/utils/scripts/copy-files.ts
@@ -13,7 +13,6 @@ const createPackageFile = async (): Promise<void> => {
 
 	const newPackageData = {
 		...packageDataOther,
-		private: false,
 		main: './index.js',
 		types: './index.d.ts',
 	};


### PR DESCRIPTION
The `private` flag that exists in the `package.json` for those packages which are publishable is breaking `pnpm`'s detection for recursive publishing.  It is determining that the package is not publishable and therefore gets skipped.

Since each of these `package.json` records has a `publishConfig` which has a `directory` pointing to `dist`, there is less benefit to flagging the source `package.json` with `private` as `pnpm` shouldn't ever try to publish the source directory.

To address this, this PR removes the `private: true` from all publishable packages and eliminates the `private: false` override when copying the `package.json` during build.