### PR TITLE
Relocate moleculer augmentation to service

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,12 +1,1 @@
 export { default as gatewayMixin, type GatewayMixinOptions } from './gatewayMixin';
-
-declare module 'moleculer' {
-	export interface GraphQLActionSchema {
-		query?: string | readonly string[];
-		mutation?: string | readonly string[];
-	}
-
-	export interface ActionSchema {
-		graphql?: GraphQLActionSchema;
-	}
-}

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -6,3 +6,14 @@ export {
 	type ServiceMixinOptions,
 	type TypeDefsFactory,
 } from './serviceMixin';
+
+declare module 'moleculer' {
+	export interface GraphQLActionSchema {
+		query?: string | readonly string[];
+		mutation?: string | readonly string[];
+	}
+
+	export interface ActionSchema {
+		graphql?: GraphQLActionSchema;
+	}
+}


### PR DESCRIPTION
After splitting the original workspace into gateway and service workspaces, the moleculer module augmentation got left behind in the gateway when really it needs to augment the service.  This PR moves the augmentation from the gateway to the service.