### PR TITLE
Shareable tsconfig

### DIFF
--- a/examples/basic/tsconfig.eslint.json
+++ b/examples/basic/tsconfig.eslint.json
@@ -1,13 +1,7 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "include": [
     "src/**/*", // source folder
-    "examples/**/*", // examples folder
-    "scripts/**/*", // scripts folder
     "./*.js", // root javascript files
     "./.*.js", // root javascript config files
     "./.*.cjs", // root commonjs config files

--- a/internal/scripts/tsconfig.eslint.json
+++ b/internal/scripts/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "@moleculer-graphql/tsconfig/tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "files": ["create-package-json.mjs"],
   "include": [
     "./*.js", // root javascript files

--- a/internal/tsconfig/tsconfig.build.json
+++ b/internal/tsconfig/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+  }
+}

--- a/internal/tsconfig/tsconfig.eslint.json
+++ b/internal/tsconfig/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "example:networking": "pnpm run build && pnpm --filter=@moleculer-graphql/example-basic run example:networking",
     "lint": "turbo run lint",
     "prettier": "turbo run prettier",
-    "test": "concurrently --max-processes 1 pnpm:typecheck pnpm:prettier pnpm:lint",
+    "test": "concurrently --max-processes 1 pnpm:typecheck pnpm:prettier pnpm:lint pnpm:coverage",
     "typecheck": "turbo run typecheck",
     "prepare": "husky install"
   },

--- a/packages/context/tsconfig.build.json
+++ b/packages/context/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/tests/**"],
   "compilerOptions": {
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
-  },
-  "include": ["src/**/*"]
+    "outDir": "./dist"
+  }
 }

--- a/packages/context/tsconfig.eslint.json
+++ b/packages/context/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "include": [
     "src/**/*", // source folder
     "./*.js", // root javascript files

--- a/packages/gateway/tsconfig.build.json
+++ b/packages/gateway/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/tests/**"],
   "compilerOptions": {
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
-  },
-  "include": ["src/**/*"]
+    "outDir": "./dist"
+  }
 }

--- a/packages/gateway/tsconfig.eslint.json
+++ b/packages/gateway/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "include": [
     "src/**/*", // source folder
     "./*.js", // root javascript files

--- a/packages/service/tsconfig.build.json
+++ b/packages/service/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/tests/**"],
   "compilerOptions": {
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
-  },
-  "include": ["src/**/*"]
+    "outDir": "./dist"
+  }
 }

--- a/packages/service/tsconfig.eslint.json
+++ b/packages/service/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "include": [
     "src/**/*", // source folder
     "./*.js", // root javascript files

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,9 +1,8 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */
-  },
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/tests/**"]
+  "exclude": ["**/*.test.ts", "**/tests/**"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
 }

--- a/packages/utils/tsconfig.eslint.json
+++ b/packages/utils/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "allowJs": true,
-    "noEmit": true
-  },
-  "extends": "./tsconfig.json",
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.eslint.json",
   "include": [
     "src/**/*", // source folder
     "./*.js", // root javascript files


### PR DESCRIPTION
This PR adds `tsconfig.eslint.json` and `tsconfig.build.json` configurations to `@moleculer-graphql/tsconfig`.  There were several repeated conventions being used in each workspace to generate their versions of these files.  Therefore, rather than repeating these patterns over and over again, it will be easier to have shareable tsconfig files for these purposes.

Unfortunately, properties like `includes`, `excludes`, `files`, and `outDir` could not be shared because typescript resolves those relative to the tsconfig file itself.  Therefore those will still need to be specified manually, but all other repeated properties and values were migrated to these new shareable configurations.