### PR TITLE
Create test suite for createValidate

### DIFF
--- a/packages/gateway/.vscode/launch.json
+++ b/packages/gateway/.vscode/launch.json
@@ -12,7 +12,7 @@
       "runtimeArgs": ["--nolazy"],
       "args": [
         "--config",
-        "${workspaceFolder}/jest.config.js",
+        "${workspaceFolder}/jest.config.ts",
         "--runInBand",
         "--no-cache",
         "--runTestsByPath",

--- a/packages/gateway/src/__tests__/createValidate.test.ts
+++ b/packages/gateway/src/__tests__/createValidate.test.ts
@@ -1,0 +1,142 @@
+import { GraphQLError, GraphQLObjectType, GraphQLSchema, GraphQLString, parse } from 'graphql';
+import type { ValidationContext, ValidationRule } from 'graphql';
+import createValidate from '../createValidate';
+
+const schema = new GraphQLSchema({
+	query: new GraphQLObjectType({
+		name: 'RootQueryType',
+		fields: {
+			hello: {
+				type: GraphQLString,
+				resolve() {
+					return 'world';
+				},
+			},
+		},
+	}),
+});
+
+describe('introspection disabled', () => {
+	const validateFn = createValidate({ introspection: false });
+
+	test('should return GraphQLError if query contains __schema', () => {
+		const query = /* GraphQL */ `
+			query {
+				__schema {
+					types {
+						name
+					}
+				}
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toBeInstanceOf(GraphQLError);
+		expect(errors[0].message).toBe(
+			'GraphQL introspection is not allowed, but the query contained __schema or __type',
+		);
+	});
+
+	test('should return GraphQLError if query contains __type', () => {
+		const query = /* GraphQL */ `
+			query {
+				__type(name: "Foo") {
+					name
+				}
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toBeInstanceOf(GraphQLError);
+		expect(errors[0].message).toBe(
+			'GraphQL introspection is not allowed, but the query contained __schema or __type',
+		);
+	});
+
+	test('should not return GraphQLError if not introspection query', () => {
+		const query = /* GraphQL */ `
+			query {
+				hello
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(0);
+	});
+});
+
+describe('introspection enabled', () => {
+	const validateFn = createValidate();
+
+	test('should not return GraphQLError if query contains __schema', () => {
+		const query = /* GraphQL */ `
+			query {
+				__schema {
+					types {
+						name
+					}
+				}
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(0);
+	});
+
+	test('should not return GraphQLError if query contains __type', () => {
+		const query = /* GraphQL */ `
+			query {
+				__type(name: "Foo") {
+					name
+				}
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(0);
+	});
+
+	test('should not return GraphQLError if not introspection query', () => {
+		const query = /* GraphQL */ `
+			query {
+				hello
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(0);
+	});
+});
+
+describe('custom rules', () => {
+	test('should return errors reported by custom rule', () => {
+		const customRule: ValidationRule = (context: ValidationContext) => ({
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			Field(node) {
+				context.reportError(new GraphQLError('Custom rule failure', { nodes: [node] }));
+			},
+		});
+
+		const validateFn = createValidate({ validationRules: [customRule] });
+
+		const query = /* GraphQL */ `
+			query {
+				hello
+			}
+		`;
+		const document = parse(query);
+
+		const errors = validateFn(schema, document);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toBeInstanceOf(GraphQLError);
+		expect(errors[0].message).toBe('Custom rule failure');
+	});
+});

--- a/packages/gateway/src/validationRules/__tests__/disableIntrospectionRule.test.ts
+++ b/packages/gateway/src/validationRules/__tests__/disableIntrospectionRule.test.ts
@@ -35,7 +35,6 @@ test('should return GraphQLError if introspection query containing __schema', ()
 	const document = parse(query);
 
 	const errors = validate(schema, document, [disableIntrospectionRule]);
-
 	expect(errors).toHaveLength(1);
 	expect(errors[0]).toBeInstanceOf(GraphQLError);
 	expect(errors[0].message).toBe(
@@ -54,7 +53,6 @@ test('should return GraphQLError if introspection query containing __type', () =
 	const document = parse(query);
 
 	const errors = validate(schema, document, [disableIntrospectionRule]);
-
 	expect(errors).toHaveLength(1);
 	expect(errors[0]).toBeInstanceOf(GraphQLError);
 	expect(errors[0].message).toBe(
@@ -71,6 +69,5 @@ test('should not return GraphQLError if not introspection query', () => {
 	const document = parse(query);
 
 	const errors = validate(schema, document, [disableIntrospectionRule]);
-
 	expect(errors).toHaveLength(0);
 });


### PR DESCRIPTION
This PR adds a test suite for the `createValidate` function which creates a custom validator to use for query validation.