### PR TITLE
[test]: Service workspace GraphQLExecutor

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -14,7 +14,7 @@
     "build:tsc": "tsc --project tsconfig.build.json",
     "clean": "pnpm run clean:build",
     "clean:build": "rimraf dist",
-    "coverage": "jest --collectCoverage --coverageReporters text-summary",
+    "coverage": "jest --collectCoverage --coverageReporters text",
     "lint": "TIMING=1 eslint . --ext js,ts",
     "lint:fix": "TIMING=1 eslint . --ext js,ts --fix",
     "prettier": "prettier . --ignore-unknown --check",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -14,7 +14,7 @@
     "build:tsc": "tsc --project tsconfig.build.json",
     "clean": "pnpm run clean:build",
     "clean:build": "rimraf dist",
-    "coverage": "jest --collectCoverage --coverageReporters text-summary",
+    "coverage": "jest --collectCoverage --coverageReporters text",
     "lint": "TIMING=1 eslint . --ext js,ts",
     "lint:fix": "TIMING=1 eslint . --ext js,ts --fix",
     "prettier": "prettier . --ignore-unknown --check",

--- a/packages/service/.vscode/launch.json
+++ b/packages/service/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Unit Tests for current workspace file",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "runtimeArgs": ["--nolazy"],
+      "args": [
+        "--config",
+        "${workspaceFolder}/jest.config.ts",
+        "--runInBand",
+        "--no-cache",
+        "--runTestsByPath",
+        "${relativeFile}",
+        "--testPathPattern=${fileDirname}",
+        "--testTimeout=10000000"
+      ],
+      "sourceMaps": true,
+      "outputCapture": "std",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**/*.js"]
+    }
+  ]
+}

--- a/packages/service/jest.config.ts
+++ b/packages/service/jest.config.ts
@@ -1,0 +1,6 @@
+import baseConfig from '@moleculer-graphql/jest-config';
+
+// temporarily set coverage threshold low while tests are being created
+const { coverageThreshold, ...restConfig } = baseConfig;
+
+export default restConfig;

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -14,7 +14,7 @@
     "build:tsc": "tsc --project tsconfig.build.json",
     "clean": "pnpm run clean:build",
     "clean:build": "rimraf dist",
-    "coverage": "jest --collectCoverage --coverageReporters text-summary",
+    "coverage": "jest --collectCoverage --coverageReporters text",
     "lint": "TIMING=1 eslint . --ext js,ts",
     "lint:fix": "TIMING=1 eslint . --ext js,ts --fix",
     "prettier": "prettier . --ignore-unknown --check",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -14,6 +14,7 @@
     "build:tsc": "tsc --project tsconfig.build.json",
     "clean": "pnpm run clean:build",
     "clean:build": "rimraf dist",
+    "coverage": "jest --collectCoverage --coverageReporters text-summary",
     "lint": "TIMING=1 eslint . --ext js,ts",
     "lint:fix": "TIMING=1 eslint . --ext js,ts --fix",
     "prettier": "prettier . --ignore-unknown --check",
@@ -53,6 +54,7 @@
     "@graphql-tools/delegate": "9.0.21",
     "@graphql-tools/utils": "9.1.3",
     "@moleculer-graphql/eslint-config": "workspace:*",
+    "@moleculer-graphql/jest-config": "workspace:*",
     "@moleculer-graphql/scripts": "workspace:*",
     "@moleculer-graphql/tsconfig": "workspace:*",
     "@types/lodash": "4.14.191",
@@ -68,7 +70,9 @@
     "eslint-plugin-jest": "27.2.0",
     "graphql": "16.6.0",
     "jest": "29.3.1",
+    "jest-mock-extended": "3.0.1",
     "moleculer": "0.14.27",
-    "rimraf": "3.0.2"
+    "rimraf": "3.0.2",
+    "ts-jest": "29.0.3"
   }
 }

--- a/packages/service/src/__tests__/GraphQLExecutor.test.ts
+++ b/packages/service/src/__tests__/GraphQLExecutor.test.ts
@@ -1,0 +1,156 @@
+import { GraphQLID, GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { mock } from 'jest-mock-extended';
+import type { Context } from 'moleculer';
+import GraphQLExecutor from '../GraphQLExecutor';
+
+const contextMock = mock<Context>();
+
+describe('simple schema', () => {
+	const schema = new GraphQLSchema({
+		query: new GraphQLObjectType({
+			name: 'RootQueryType',
+			fields: {
+				hello: {
+					type: GraphQLString,
+					resolve() {
+						return 'Hello world';
+					},
+				},
+				greet: {
+					type: GraphQLString,
+					args: { name: { type: GraphQLString } },
+					resolve(parent, args) {
+						return `Hello ${args.name}`;
+					},
+				},
+			},
+		}),
+	});
+	const graphQLExecutor = new GraphQLExecutor(schema);
+
+	test('should execute graphql operation', async () => {
+		const query = /* GraphQL */ `
+			query {
+				greet(name: "John Doe")
+			}
+		`;
+
+		const result = await graphQLExecutor.execute(contextMock, query, null, null);
+		const expected = { data: { greet: 'Hello John Doe' } };
+		expect(result).toEqual(expected);
+	});
+
+	test('should execute graphql operation with variables', async () => {
+		const query = /* GraphQL */ `
+			query Foo($name: String) {
+				greet(name: $name)
+			}
+		`;
+		const variables = { name: 'Jane Doe' };
+
+		const result = await graphQLExecutor.execute(contextMock, query, variables, null);
+		const expected = { data: { greet: 'Hello Jane Doe' } };
+		expect(result).toEqual(expected);
+	});
+
+	test('should execute graphql operation with operation name', async () => {
+		const query = /* GraphQL */ `
+			query John {
+				greet(name: "John Doe")
+			}
+			query Jane {
+				greet(name: "Jane Doe")
+			}
+		`;
+		const operationName = 'John';
+
+		const result = await graphQLExecutor.execute(contextMock, query, null, operationName);
+		const expected = { data: { greet: 'Hello John Doe' } };
+		expect(result).toEqual(expected);
+	});
+
+	test('should execute multiple graphql operations', async () => {
+		const query = /* GraphQL */ `
+			query {
+				greet(name: "John Doe")
+				hello
+			}
+		`;
+
+		const result = await graphQLExecutor.execute(contextMock, query, null, null);
+		const expected = { data: { greet: 'Hello John Doe', hello: 'Hello world' } };
+		expect(result).toEqual(expected);
+	});
+
+	test('should execute multiple graphql operations with aliases', async () => {
+		const query = /* GraphQL */ `
+			query {
+				John: greet(name: "John Doe")
+				Jane: greet(name: "Jane Doe")
+			}
+		`;
+
+		const result = await graphQLExecutor.execute(contextMock, query, null, null);
+		const expected = {
+			data: { John: 'Hello John Doe', Jane: 'Hello Jane Doe' },
+		};
+		expect(result).toEqual(expected);
+	});
+});
+
+describe('complex schemas', () => {
+	const bookObject = new GraphQLObjectType({
+		name: 'book',
+		fields: {
+			id: { type: GraphQLID },
+			title: { type: GraphQLString },
+		},
+	});
+	const authorObject = new GraphQLObjectType({
+		name: 'author',
+		fields: {
+			name: { type: GraphQLString },
+			book: {
+				type: bookObject,
+				resolve(parent) {
+					return { id: parent.bookId, title: 'Of Mice and Men' };
+				},
+			},
+		},
+	});
+
+	const schema = new GraphQLSchema({
+		query: new GraphQLObjectType({
+			name: 'RootQueryType',
+			fields: {
+				author: {
+					type: authorObject,
+					resolve() {
+						return { name: 'John Steinbeck', bookId: '1' };
+					},
+				},
+			},
+		}),
+	});
+	const graphQLExecutor = new GraphQLExecutor(schema);
+
+	test('should child resolve book object', async () => {
+		const query = /* GraphQL */ `
+			query {
+				author {
+					name
+					book {
+						id
+						title
+					}
+				}
+			}
+		`;
+
+		const result = await graphQLExecutor.execute(contextMock, query, null, null);
+		const expected = {
+			data: { author: { name: 'John Steinbeck', book: { id: '1', title: 'Of Mice and Men' } } },
+		};
+		expect(result).toEqual(expected);
+	});
+});

--- a/packages/service/tsconfig.eslint.json
+++ b/packages/service/tsconfig.eslint.json
@@ -3,6 +3,7 @@
   "include": [
     "src/**/*", // source folder
     "./*.js", // root javascript files
+    "./*.ts", // root typescript files
     "./.*.js", // root javascript config files
     "./.*.cjs", // root commonjs config files
     "__mocks__/**/*" // jest mocks

--- a/packages/service/tsconfig.test.json
+++ b/packages/service/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@moleculer-graphql/tsconfig/tsconfig.test.json"
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,7 @@
     "build:tsc": "tsc --project tsconfig.build.json",
     "clean": "pnpm run clean:build",
     "clean:build": "rimraf dist",
-    "coverage": "jest --collectCoverage --coverageReporters text-summary",
+    "coverage": "jest --collectCoverage --coverageReporters text",
     "lint": "TIMING=1 eslint . --ext js,ts",
     "lint:fix": "TIMING=1 eslint . --ext js,ts --fix",
     "prettier": "prettier . --ignore-unknown --check",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,7 @@ importers:
       '@graphql-tools/utils': 9.1.3
       '@moleculer-graphql/context': workspace:^
       '@moleculer-graphql/eslint-config': workspace:*
+      '@moleculer-graphql/jest-config': workspace:*
       '@moleculer-graphql/scripts': workspace:*
       '@moleculer-graphql/tsconfig': workspace:*
       '@moleculer-graphql/utils': workspace:^
@@ -271,9 +272,11 @@ importers:
       eslint-plugin-jest: 27.2.0
       graphql: 16.6.0
       jest: 29.3.1
+      jest-mock-extended: 3.0.1
       lodash: ^4.17.21
       moleculer: 0.14.27
       rimraf: 3.0.2
+      ts-jest: 29.0.3
     dependencies:
       '@graphql-tools/merge': 8.3.14_graphql@16.6.0
       '@graphql-tools/schema': 9.0.12_graphql@16.6.0
@@ -285,6 +288,7 @@ importers:
       '@graphql-tools/delegate': 9.0.21_graphql@16.6.0
       '@graphql-tools/utils': 9.1.3_graphql@16.6.0
       '@moleculer-graphql/eslint-config': link:../../internal/eslint-config
+      '@moleculer-graphql/jest-config': link:../../internal/jest-config
       '@moleculer-graphql/scripts': link:../../internal/scripts
       '@moleculer-graphql/tsconfig': link:../../internal/tsconfig
       '@types/lodash': 4.14.191
@@ -300,8 +304,10 @@ importers:
       eslint-plugin-jest: 27.2.0_ejranoj46qqsbprlxeelud62h4
       graphql: 16.6.0
       jest: 29.3.1
+      jest-mock-extended: 3.0.1_jest@29.3.1
       moleculer: 0.14.27
       rimraf: 3.0.2
+      ts-jest: 29.0.3_jest@29.3.1
     publishDirectory: dist
 
   packages/utils:


### PR DESCRIPTION
This PR establishes the tooling to run jest tests in the service workspace.  It additionally adds a test suite for the `GraphQLExecutor` class.