### PR TITLE
Rename tsconfig build exclude to __tests__

### DIFF
--- a/packages/context/tsconfig.build.json
+++ b/packages/context/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/tests/**"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/packages/gateway/tsconfig.build.json
+++ b/packages/gateway/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/tests/**"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/packages/service/tsconfig.build.json
+++ b/packages/service/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/tests/**"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "@moleculer-graphql/tsconfig/tsconfig.build.json",
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/tests/**"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"],
   "compilerOptions": {
     "outDir": "./dist"
   }


### PR DESCRIPTION
The build configuration is currently excluding folders name `tests` from the build output.  However, tests are not going into `tests` folders but rather `__tests__` folders.  This updates the config to exclude `__tests__` instead.