### PR TITLE
Add tests for request handler

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-jest": "27.2.0",
     "graphql": "16.6.0",
     "jest": "29.3.1",
+    "jest-mock-extended": "3.0.1",
     "moleculer": "0.14.27",
     "moleculer-web": "0.10.5",
     "rimraf": "3.0.2",

--- a/packages/gateway/src/__tests__/RequestHandler.test.ts
+++ b/packages/gateway/src/__tests__/RequestHandler.test.ts
@@ -1,0 +1,172 @@
+import type { ServerResponse } from 'http';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { createHandler } from 'graphql-http';
+import { mock } from 'jest-mock-extended';
+import type { IncomingRequest } from 'moleculer-web';
+import RequestHandler from '../RequestHandler';
+
+jest.mock('graphql-http');
+
+const schema = new GraphQLSchema({
+	query: new GraphQLObjectType({
+		name: 'RootQueryType',
+		fields: {
+			hello: {
+				type: GraphQLString,
+				resolve() {
+					return 'Hello world';
+				},
+			},
+		},
+	}),
+});
+
+const handler = jest.fn();
+
+beforeEach(() => {
+	(createHandler as jest.Mock).mockReturnValue(handler);
+});
+
+describe('errors', () => {
+	test('should respond with 500 if request url is undefined', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn());
+
+		const requestMock = mock<IncomingRequest>();
+		requestMock.url = undefined;
+		const responseMock = mock<ServerResponse>();
+		responseMock.writeHead.mockReturnValue(responseMock);
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).toHaveBeenCalledWith(500, 'Missing request URL');
+		expect(responseMock.end).toHaveBeenCalledTimes(1);
+	});
+
+	test('should respond with 500 if request method is undefined', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn());
+
+		const requestMock = mock<IncomingRequest>();
+		requestMock.method = undefined;
+		const responseMock = mock<ServerResponse>();
+		responseMock.writeHead.mockReturnValue(responseMock);
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).toHaveBeenCalledWith(500, 'Missing request method');
+		expect(responseMock.end).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('graphiql', () => {
+	test('should respond with graphiql if introspection and showGraphiQL are both true', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn(), {
+			showGraphiQL: true,
+			introspection: true,
+		});
+
+		const requestMock = mock<IncomingRequest>();
+		requestMock.method = 'GET';
+		requestMock.query = {};
+		requestMock.headers = { accept: 'text/html' };
+		const responseMock = mock<ServerResponse>();
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).toHaveBeenCalledWith(
+			200,
+			expect.objectContaining({
+				'Content-Type': 'text/html',
+				'Content-Length': expect.any(Number),
+			}),
+		);
+	});
+
+	test('should not respond with graphiql if introspection is false', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn(), {
+			showGraphiQL: true,
+			introspection: false,
+		});
+
+		const requestMock = mock<IncomingRequest>();
+		const responseMock = mock<ServerResponse>();
+		responseMock.writeHead.mockReturnValue(responseMock);
+
+		handler.mockResolvedValue([
+			'body',
+			{
+				status: 500,
+				statusText: 'Internal Server Error',
+				headers: { 'Content-Type': 'text/html' },
+			},
+		]);
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).not.toHaveBeenCalledWith(
+			200,
+			expect.objectContaining({
+				'Content-Type': 'text/html',
+				'Content-Length': expect.any(Number),
+			}),
+		);
+	});
+
+	test('should not respond with graphiql if showGraphiQL is false', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn(), {
+			showGraphiQL: false,
+			introspection: true,
+		});
+
+		const requestMock = mock<IncomingRequest>();
+		const responseMock = mock<ServerResponse>();
+		responseMock.writeHead.mockReturnValue(responseMock);
+
+		handler.mockResolvedValue([
+			'body',
+			{
+				status: 500,
+				statusText: 'Internal Server Error',
+				headers: { 'Content-Type': 'text/html' },
+			},
+		]);
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).not.toHaveBeenCalledWith(
+			200,
+			expect.objectContaining({
+				'Content-Type': 'text/html',
+				'Content-Length': expect.any(Number),
+			}),
+		);
+	});
+});
+
+describe('graphql handling', () => {
+	test('should handle valid graphql request', async () => {
+		const requestHandler = new RequestHandler(schema, jest.fn());
+
+		const requestMock = mock<IncomingRequest>();
+		const responseMock = mock<ServerResponse>();
+		responseMock.writeHead.mockReturnValue(responseMock);
+
+		handler.mockResolvedValue([
+			'body',
+			{ status: 200, statusText: 'OK', headers: { 'Content-Type': 'text/html' } },
+		]);
+
+		await requestHandler.handle(requestMock, responseMock);
+
+		expect(responseMock.writeHead).toHaveBeenCalledWith(200, 'OK', { 'Content-Type': 'text/html' });
+		expect(responseMock.end).toHaveBeenCalledWith('body');
+
+		expect(handler).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: requestMock.url,
+				method: requestMock.method,
+				headers: requestMock.headers,
+				raw: requestMock,
+			}),
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ importers:
       graphql: 16.6.0
       graphql-http: ^1.10.0
       jest: 29.3.1
+      jest-mock-extended: 3.0.1
       lodash: ^4.17.21
       moleculer: 0.14.27
       moleculer-web: 0.10.5
@@ -240,6 +241,7 @@ importers:
       eslint-plugin-jest: 27.2.0_ejranoj46qqsbprlxeelud62h4
       graphql: 16.6.0
       jest: 29.3.1
+      jest-mock-extended: 3.0.1_jest@29.3.1
       moleculer: 0.14.27
       moleculer-web: 0.10.5_moleculer@0.14.27
       rimraf: 3.0.2


### PR DESCRIPTION
This PR adds tests for the `RequestHandler` class in the `gateway` workspace.